### PR TITLE
Make sure basic tools keep installed in the container.

### DIFF
--- a/6/Dockerfile-alpine
+++ b/6/Dockerfile-alpine
@@ -1,10 +1,9 @@
 FROM drupaldocker/php-dev:5.6-alpine-cli
 MAINTAINER drupal-docker
 
-RUN apk add --no-cache --virtual .dd-build-deps mysql-client openssh-client rsync \
+RUN apk add --no-cache mysql-client openssh-client rsync \
   && composer global require drush/drush:6.* \
   && ln -s ~/.composer/vendor/bin/drush /usr/local/bin/drush \
-  && drush core-status -y \
-  && apk del .dd-build-deps
+  && drush core-status -y
 
 CMD ["drush", "core-cli"]

--- a/7/Dockerfile-alpine
+++ b/7/Dockerfile-alpine
@@ -1,10 +1,9 @@
 FROM drupaldocker/php-dev:5.6-alpine-cli
 MAINTAINER drupal-docker
 
-RUN apk add --no-cache --virtual .dd-build-deps mysql-client openssh-client rsync \
+RUN apk add --no-cache mysql-client openssh-client rsync \
   && composer global require drush/drush:7.* \
   && ln -s ~/.composer/vendor/bin/drush /usr/local/bin/drush \
-  && drush core-status -y \
-  && apk del .dd-build-deps
+  && drush core-status -y
 
 CMD ["drush", "core-cli"]

--- a/8/Dockerfile-alpine
+++ b/8/Dockerfile-alpine
@@ -1,10 +1,9 @@
 FROM drupaldocker/php-dev:5.6-alpine-cli
 MAINTAINER drupal-docker
 
-RUN apk add --no-cache --virtual .dd-build-deps mysql-client openssh-client rsync \
+RUN apk add --no-cache mysql-client openssh-client rsync \
   && composer global require drush/drush:8.* \
   && ln -s ~/.composer/vendor/bin/drush /usr/local/bin/drush \
-  && drush core-status -y \
-  && apk del .dd-build-deps
+  && drush core-status -y
 
 CMD ["drush", "core-cli"]

--- a/master/Dockerfile-alpine
+++ b/master/Dockerfile-alpine
@@ -1,14 +1,13 @@
 FROM drupaldocker/php-dev:5.6-alpine-cli
 MAINTAINER drupal-docker
 
-RUN apk add --no-cache --virtual .dd-build-deps mysql-client openssh-client rsync \
+RUN apk add --no-cache mysql-client openssh-client rsync \
   && cd ~ \
   && git clone --depth 1 --branch master https://github.com/drush-ops/drush.git drush \
   && cd drush \
   && composer install \
   && ln -s ~/drush/drush /usr/local/bin/drush \
   && drush core-status -y \
-  && drush core-init -y \
-  && apk del .dd-build-deps
+  && drush core-init -y
 
 CMD ["drush", "core-cli"]


### PR DESCRIPTION
Tools such as mysql client and rsync are currently installed as build deps and removed at the end. We should keep them.
