### PR TITLE
Fix markdown table formatting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 Drush
------------------------
+=====
 
 [![Build Status](https://travis-ci.org/drupal-docker/drush.svg?branch=master)](https://travis-ci.org/drupal-docker/drush)
 [![Docker Pulls](https://img.shields.io/docker/pulls/drupaldocker/drush.svg?maxAge=2592000)](https://hub.docker.com/r/drupaldocker/drush)
 
-Version | Tags | Dockerfile
---- | --- | --- | ---
-master | `master`, `9` | [Dockerfile](https://github.com/drupal-docker/drush/blob/master/master/Dockerfile)
- | `9-alpine` | [Dockerfile](https://github.com/drupal-docker/drush/blob/master/master/Dockerfile-alpine)
-8 | `latest`, `8` | [Dockerfile](https://github.com/drupal-docker/drush/blob/master/8/Dockerfile)
- | `8-alpine` | [Dockerfile](https://github.com/drupal-docker/drush/blob/master/8/Dockerfile-alpine)
-7 | `7` | [Dockerfile](https://github.com/drupal-docker/drush/blob/master/7/Dockerfile)
- | `7-alpine` | [Dockerfile](https://github.com/drupal-docker/drush/blob/master/7/Dockerfile-alpine)
-6 | `6` | [Dockerfile](https://github.com/drupal-docker/drush/blob/master/6/Dockerfile)
- | `6-alpine` | [Dockerfile](https://github.com/drupal-docker/drush/blob/master/6/Dockerfile-alpine)
+Version | Tags          | Dockerfile
+--------|---------------|------------
+master  | `master`, `9` | [Dockerfile 9](https://github.com/drupal-docker/drush/blob/master/master/Dockerfile)
+.       | `9-alpine`    | [Dockerfile 9-alpine](https://github.com/drupal-docker/drush/blob/master/master/Dockerfile-alpine)
+8       | `latest`, `8` | [Dockerfile 8](https://github.com/drupal-docker/drush/blob/master/8/Dockerfile)
+.       | `8-alpine`    | [Dockerfile 8-alpine](https://github.com/drupal-docker/drush/blob/master/8/Dockerfile-alpine)
+7       | `7`           | [Dockerfile 7](https://github.com/drupal-docker/drush/blob/master/7/Dockerfile)
+.       | `7-alpine`    | [Dockerfile 7-alpine](https://github.com/drupal-docker/drush/blob/master/7/Dockerfile-alpine)
+6       | `6`           | [Dockerfile 6](https://github.com/drupal-docker/drush/blob/master/6/Dockerfile)
+.       | `6-alpine`    | [Dockerfile 6-alpine](https://github.com/drupal-docker/drush/blob/master/6/Dockerfile-alpine)


### PR DESCRIPTION
## Proposed Changes

- Use a top level heading.
- Fix the markdown syntax of the versions table. 
- Pad versions table for readability in plain-text.
- Fix a11y of Dockerfile download links.